### PR TITLE
Add space between log message and attributes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -656,7 +656,7 @@ impl LogFormatter {
                     }
                 }
 
-                let s = String::from(msg) + attr.dump().as_ref();
+                let s = String::from(msg) + " " + attr.dump().as_ref();
                 return Ok(self.format_line(
                     d,
                     log_level,


### PR DESCRIPTION
Log messages without attribute substitutions do not have space between the message and attributes:
`2020-08-04T18:45:09.642-04:00 I  NETWORK  [listener] Waiting for connections{"port":27017,"ssl":"off"}`

This PR changes messages so they look like this now:
`2020-08-04T18:45:09.642-04:00 I  NETWORK  [listener] Waiting for connections {"port":27017,"ssl":"off"}`